### PR TITLE
fix: changed type from string to int

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/WebApps/Helper/WebAppHelper.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/WebApps/Helper/WebAppHelper.swift
@@ -307,7 +307,7 @@ extension WebAppHelper : WKScriptMessageHandler {
 
         if let data = dict["data"] {
             
-            if let type = data["type"] as? String, let metaData = data["metaData"] as? AnyObject {
+            if let type = data["type"] as? Int, let metaData = data["metaData"] as? AnyObject {
                 
             
             let params = ["type": type as AnyObject,


### PR DESCRIPTION
we're doing this because on relay it expects an int and so does sphinx-bridge, I tested it and it looks like it working fine now