### PR TITLE
Test flight main views navigation changes

### DIFF
--- a/com.stakwork.sphinx.desktop/Generated/StoryboardScenes.swift
+++ b/com.stakwork.sphinx.desktop/Generated/StoryboardScenes.swift
@@ -49,6 +49,8 @@ internal enum StoryboardScene {
         
         internal static let dashboardPresenterViewController = SceneType<DashboardPresenterViewController>(storyboard: Dashboard.self, identifier: "DashboardPresenterViewController")
         
+        internal static let dashboardDetailViewController = SceneType<DashboardDetailViewController>(storyboard: Dashboard.self, identifier: "DashboardDetailViewController")
+        
         internal static let chatListViewController = SceneType<ChatListViewController>(storyboard: Dashboard.self, identifier: "ChatListViewController")
         
         @available(macOS 10.15.1, *)

--- a/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
+++ b/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
@@ -186,6 +186,25 @@ class WindowsManager {
         }
     }
     
+    func showVCOnRightmostPanelWindow(
+        with title: String,
+        identifier: String? = nil,
+        contentVC: NSViewController,
+        hideDivider: Bool = true,
+        shouldReplace: Bool = true
+    ) {
+        guard let keyWindow = NSApplication.shared.keyWindow, 
+                let dashboardVC = keyWindow.contentViewController as? DashboardViewController
+        else {
+            return
+        }
+        print("Here is the identifier: \(identifier)")
+        dashboardVC.rightDetailSplittedView.isHidden = false
+        if let detailVC = dashboardVC.dashboardDetailViewController {
+            detailVC.displayVC(contentVC, vcTitle: title, shouldReplace: shouldReplace)
+        }
+    }
+    
     func showVCOnCurrentWindow(
         with title: String,
         identifier: String? = nil,
@@ -321,36 +340,23 @@ class WindowsManager {
     }
     
     func showPubKeyWindow(vc: NSViewController, window: NSWindow?) {
-        showNewWindow(
-            with: "pubkey".localized,
-            size: CGSize(width: 400, height: 600),
-            centeredIn: window,
-            identifier: "pubkey-window",
-            contentVC: vc,
-            shouldClose: true
-        )
+        showVCOnRightmostPanelWindow(with: "pubkey".localized, 
+                                     identifier: "pubkey-window",
+                                     contentVC: vc,
+                                     shouldReplace: false)
     }
     
     func showTribeQRWindow(vc: NSViewController, window: NSWindow?) {
-        showNewWindow(
-            with: "share.group.link".localized,
-            size: CGSize(width: 400, height: 600),
-            centeredIn: window,
-            identifier: "tribe-qr-window",
-            contentVC: vc,
-            shouldClose: true
-        )
+        showVCOnRightmostPanelWindow(with: "share".localized,
+                                     identifier: "share-window",
+                                     contentVC: vc,
+                                     shouldReplace: false)
     }
     
     func showChatDetailsWindow(vc: NSViewController, window: NSWindow?, title: String, identifier: String, size: CGSize) {
-        showNewWindow(
-            with: title,
-            size: size,
-            centeredIn: window,
-            identifier: identifier,
-            contentVC: vc,
-            shouldClose: true
-        )
+        showVCOnRightmostPanelWindow(with: title,
+                                     identifier: identifier,
+                                     contentVC: vc)
     }
     
     func showProfileWindow(vc: NSViewController) {

--- a/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
+++ b/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
@@ -198,7 +198,6 @@ class WindowsManager {
         else {
             return
         }
-        print("Here is the identifier: \(identifier)")
         dashboardVC.rightDetailSplittedView.isHidden = false
         if let detailVC = dashboardVC.dashboardDetailViewController {
             detailVC.displayVC(contentVC, vcTitle: title, shouldReplace: shouldReplace)

--- a/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
+++ b/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
@@ -190,7 +190,6 @@ class WindowsManager {
         with title: String,
         identifier: String? = nil,
         contentVC: NSViewController,
-        hideDivider: Bool = true,
         shouldReplace: Bool = true
     ) {
         guard let keyWindow = NSApplication.shared.keyWindow, 

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
@@ -1891,18 +1891,18 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="WBG-zn-Bex" customClass="DashboardDetailHeaderView" customModule="Sphinx" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="818" width="600" height="72"/>
+                                                    <rect key="frame" x="0.0" y="830" width="600" height="60"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="72" id="tMb-ey-vyo"/>
+                                                        <constraint firstAttribute="height" constant="60" id="tMb-ey-vyo"/>
                                                     </constraints>
                                                 </customView>
-                                                <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6E-8Z-I04" customClass="ThreadVCContainer" customModule="Sphinx" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="e6E-8Z-I04" customClass="ThreadVCContainer" customModule="Sphinx" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="830"/>
                                                     <subviews>
                                                         <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Syu-JH-Oyd">
-                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="830"/>
                                                             <view key="contentView" id="JD7-es-ZnE">
-                                                                <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="600" height="830"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             </view>
                                                             <color key="fillColor" name="Body"/>
@@ -1919,7 +1919,7 @@
                                             <constraints>
                                                 <constraint firstItem="WBG-zn-Bex" firstAttribute="leading" secondItem="tZd-td-tjp" secondAttribute="leading" id="1HM-WJ-p4b"/>
                                                 <constraint firstAttribute="trailing" secondItem="e6E-8Z-I04" secondAttribute="trailing" id="3mB-Fe-BQ2"/>
-                                                <constraint firstItem="e6E-8Z-I04" firstAttribute="top" secondItem="tZd-td-tjp" secondAttribute="top" id="H35-ax-401"/>
+                                                <constraint firstItem="e6E-8Z-I04" firstAttribute="top" secondItem="WBG-zn-Bex" secondAttribute="bottom" id="H35-ax-401"/>
                                                 <constraint firstItem="WBG-zn-Bex" firstAttribute="top" secondItem="tZd-td-tjp" secondAttribute="top" id="Jnd-w6-0Uw"/>
                                                 <constraint firstItem="e6E-8Z-I04" firstAttribute="leading" secondItem="tZd-td-tjp" secondAttribute="leading" id="g1h-tf-ED9"/>
                                                 <constraint firstAttribute="bottom" secondItem="e6E-8Z-I04" secondAttribute="bottom" id="iDb-5c-85C"/>
@@ -1945,6 +1945,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="containerView" destination="e6E-8Z-I04" id="V8J-Zu-Fpa"/>
                         <outlet property="headerView" destination="WBG-zn-Bex" id="wKK-Dr-DHS"/>
                     </connections>
                 </viewController>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
@@ -94,7 +94,7 @@
                                                         <constraints>
                                                             <constraint firstAttribute="bottom" secondItem="19x-YZ-MGN" secondAttribute="bottom" id="7Cj-RW-gTC"/>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="DhN-a9-O1h"/>
-                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="400" id="K12-UG-WFt"/>
+                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="448" id="K12-UG-WFt"/>
                                                             <constraint firstAttribute="trailing" secondItem="19x-YZ-MGN" secondAttribute="trailing" id="Pmk-FB-HXn"/>
                                                             <constraint firstItem="19x-YZ-MGN" firstAttribute="top" secondItem="5cv-NJ-L3p" secondAttribute="top" id="qtk-7w-pEt"/>
                                                             <constraint firstItem="19x-YZ-MGN" firstAttribute="leading" secondItem="5cv-NJ-L3p" secondAttribute="leading" id="wAi-Iz-go6"/>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
-        <plugIn identifier="com.apple.WebKit2IBPlugin" version="22155"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <plugIn identifier="com.apple.WebKit2IBPlugin" version="22505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -59,12 +59,63 @@
                                                     <segue destination="Pz4-0N-V1w" kind="embed" identifier="ChatViewControllerSegue" id="QPQ-fP-nMH"/>
                                                 </connections>
                                             </containerView>
+                                            <splitView arrangesAllSubviews="NO" dividerStyle="paneSplitter" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MBk-nh-nye">
+                                                <rect key="frame" x="0.0" y="0.0" width="640" height="499"/>
+                                                <subviews>
+                                                    <customView id="kk1-mv-gZj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="317" height="499"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <subviews>
+                                                            <containerView translatesAutoresizingMaskIntoConstraints="NO" id="tYG-E5-Q7o">
+                                                                <rect key="frame" x="0.0" y="0.0" width="317" height="499"/>
+                                                                <connections>
+                                                                    <segue destination="kXm-gj-szD" kind="embed" id="dYj-dA-VwQ"/>
+                                                                </connections>
+                                                            </containerView>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstItem="tYG-E5-Q7o" firstAttribute="leading" secondItem="kk1-mv-gZj" secondAttribute="leading" id="5go-Ua-NV1"/>
+                                                            <constraint firstItem="tYG-E5-Q7o" firstAttribute="top" secondItem="kk1-mv-gZj" secondAttribute="top" id="7aR-aw-8wf"/>
+                                                            <constraint firstAttribute="bottom" secondItem="tYG-E5-Q7o" secondAttribute="bottom" id="KcT-uq-C2G"/>
+                                                            <constraint firstAttribute="trailing" secondItem="tYG-E5-Q7o" secondAttribute="trailing" id="nbR-6v-cH9"/>
+                                                        </constraints>
+                                                    </customView>
+                                                    <customView id="5cv-NJ-L3p">
+                                                        <rect key="frame" x="327" y="0.0" width="313" height="499"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <subviews>
+                                                            <containerView translatesAutoresizingMaskIntoConstraints="NO" id="19x-YZ-MGN">
+                                                                <rect key="frame" x="0.0" y="0.0" width="313" height="499"/>
+                                                                <connections>
+                                                                    <segue destination="EAg-cT-EfO" kind="embed" id="D6j-jJ-9pz"/>
+                                                                </connections>
+                                                            </containerView>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="bottom" secondItem="19x-YZ-MGN" secondAttribute="bottom" id="7Cj-RW-gTC"/>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="DhN-a9-O1h"/>
+                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="400" id="K12-UG-WFt"/>
+                                                            <constraint firstAttribute="trailing" secondItem="19x-YZ-MGN" secondAttribute="trailing" id="Pmk-FB-HXn"/>
+                                                            <constraint firstItem="19x-YZ-MGN" firstAttribute="top" secondItem="5cv-NJ-L3p" secondAttribute="top" id="qtk-7w-pEt"/>
+                                                            <constraint firstItem="19x-YZ-MGN" firstAttribute="leading" secondItem="5cv-NJ-L3p" secondAttribute="leading" id="wAi-Iz-go6"/>
+                                                        </constraints>
+                                                    </customView>
+                                                </subviews>
+                                                <holdingPriorities>
+                                                    <real value="250"/>
+                                                    <real value="251"/>
+                                                </holdingPriorities>
+                                            </splitView>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="sNN-Zp-F4E" firstAttribute="leading" secondItem="pXC-Wm-9tR" secondAttribute="leading" id="6tP-vQ-TO0"/>
                                             <constraint firstAttribute="trailing" secondItem="sNN-Zp-F4E" secondAttribute="trailing" id="7X3-zf-dtv"/>
                                             <constraint firstAttribute="bottom" secondItem="sNN-Zp-F4E" secondAttribute="bottom" id="DP6-6w-bB6"/>
+                                            <constraint firstItem="MBk-nh-nye" firstAttribute="leading" secondItem="pXC-Wm-9tR" secondAttribute="leading" id="bsO-Pm-aKa"/>
                                             <constraint firstItem="sNN-Zp-F4E" firstAttribute="top" secondItem="pXC-Wm-9tR" secondAttribute="top" id="iUL-Di-EGy"/>
+                                            <constraint firstAttribute="trailing" secondItem="MBk-nh-nye" secondAttribute="trailing" id="j3L-uG-7eq"/>
+                                            <constraint firstItem="MBk-nh-nye" firstAttribute="top" secondItem="pXC-Wm-9tR" secondAttribute="top" id="vtM-wU-dtk"/>
+                                            <constraint firstAttribute="bottom" secondItem="MBk-nh-nye" secondAttribute="bottom" id="xko-mf-byj"/>
                                         </constraints>
                                     </customView>
                                 </subviews>
@@ -270,6 +321,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="dashboardRightSplitView" destination="MBk-nh-nye" id="AiS-HN-ZMN"/>
                         <outlet property="dashboardSplitView" destination="PrF-LO-tpi" id="Mc9-G7-SVA"/>
                         <outlet property="leftSplittedView" destination="TtT-Yv-CaJ" id="1we-Fa-PVs"/>
                         <outlet property="modalsContainerView" destination="dbw-3D-RbV" id="UXb-da-QeH"/>
@@ -282,7 +334,8 @@
                         <outlet property="presenterHeaderDivider" destination="saa-Qf-nSs" id="8ei-un-IPu"/>
                         <outlet property="presenterTitleLabel" destination="sht-p7-2gS" id="jHb-rC-HnK"/>
                         <outlet property="presenterViewHeightConstraint" destination="Cc6-6n-Pdu" id="Ntd-v2-QCR"/>
-                        <outlet property="rightSplittedView" destination="pXC-Wm-9tR" id="QM1-VT-C9Q"/>
+                        <outlet property="rightDetailSplittedView" destination="5cv-NJ-L3p" id="aog-r3-zZw"/>
+                        <outlet property="rightSplittedView" destination="kk1-mv-gZj" id="zpQ-On-mJF"/>
                     </connections>
                 </viewController>
                 <customObject id="6tE-iB-pdf" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1793,6 +1846,32 @@
                 <customObject id="2BW-Mq-dQo" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1060" y="2456"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="yV4-JH-TKQ">
+            <objects>
+                <viewController id="kXm-gj-szD" sceneMemberID="viewController">
+                    <view key="view" id="ZUZ-mA-Emo">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="Dxb-E7-Ryx" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="319" y="-375"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="wYi-r6-qtl">
+            <objects>
+                <viewController id="EAg-cT-EfO" sceneMemberID="viewController">
+                    <view key="view" id="LhQ-V1-J5y">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="YXJ-dv-CVQ" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-671" y="-375"/>
         </scene>
     </scenes>
     <resources>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
@@ -1873,6 +1873,85 @@
             </objects>
             <point key="canvasLocation" x="-671" y="-375"/>
         </scene>
+        <!--Dashboard Detail View Controller-->
+        <scene sceneID="tt8-YW-Szz">
+            <objects>
+                <viewController storyboardIdentifier="DashboardDetailViewController" id="h1b-62-701" customClass="DashboardDetailViewController" customModule="Sphinx" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="Pz5-VD-l9P">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="sHB-Bt-i1k">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                <subviews>
+                                    <box boxType="custom" borderType="none" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Jvo-i8-wHM">
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                        <view key="contentView" id="tZd-td-tjp">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="WBG-zn-Bex" customClass="DashboardDetailHeaderView" customModule="Sphinx" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="818" width="600" height="72"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="72" id="tMb-ey-vyo"/>
+                                                    </constraints>
+                                                </customView>
+                                                <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6E-8Z-I04" customClass="ThreadVCContainer" customModule="Sphinx" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                                    <subviews>
+                                                        <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Syu-JH-Oyd">
+                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                                            <view key="contentView" id="JD7-es-ZnE">
+                                                                <rect key="frame" x="0.0" y="0.0" width="600" height="890"/>
+                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            </view>
+                                                            <color key="fillColor" name="Body"/>
+                                                        </box>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstAttribute="trailing" secondItem="Syu-JH-Oyd" secondAttribute="trailing" id="DoG-OV-Ffy"/>
+                                                        <constraint firstItem="Syu-JH-Oyd" firstAttribute="leading" secondItem="e6E-8Z-I04" secondAttribute="leading" id="GKM-wl-x6o"/>
+                                                        <constraint firstItem="Syu-JH-Oyd" firstAttribute="top" secondItem="e6E-8Z-I04" secondAttribute="top" id="T6X-LC-lZL"/>
+                                                        <constraint firstAttribute="bottom" secondItem="Syu-JH-Oyd" secondAttribute="bottom" id="Xqr-gy-pgi"/>
+                                                    </constraints>
+                                                </customView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="WBG-zn-Bex" firstAttribute="leading" secondItem="tZd-td-tjp" secondAttribute="leading" id="1HM-WJ-p4b"/>
+                                                <constraint firstAttribute="trailing" secondItem="e6E-8Z-I04" secondAttribute="trailing" id="3mB-Fe-BQ2"/>
+                                                <constraint firstItem="e6E-8Z-I04" firstAttribute="top" secondItem="tZd-td-tjp" secondAttribute="top" id="H35-ax-401"/>
+                                                <constraint firstItem="WBG-zn-Bex" firstAttribute="top" secondItem="tZd-td-tjp" secondAttribute="top" id="Jnd-w6-0Uw"/>
+                                                <constraint firstItem="e6E-8Z-I04" firstAttribute="leading" secondItem="tZd-td-tjp" secondAttribute="leading" id="g1h-tf-ED9"/>
+                                                <constraint firstAttribute="bottom" secondItem="e6E-8Z-I04" secondAttribute="bottom" id="iDb-5c-85C"/>
+                                                <constraint firstAttribute="trailing" secondItem="WBG-zn-Bex" secondAttribute="trailing" id="tSk-FR-lq3"/>
+                                            </constraints>
+                                        </view>
+                                        <color key="fillColor" name="Body"/>
+                                    </box>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="Jvo-i8-wHM" secondAttribute="trailing" id="NcP-3B-wDH"/>
+                                    <constraint firstItem="Jvo-i8-wHM" firstAttribute="top" secondItem="sHB-Bt-i1k" secondAttribute="top" id="Uby-Mc-5aN"/>
+                                    <constraint firstAttribute="bottom" secondItem="Jvo-i8-wHM" secondAttribute="bottom" id="eQ0-Tt-yOp"/>
+                                    <constraint firstItem="Jvo-i8-wHM" firstAttribute="leading" secondItem="sHB-Bt-i1k" secondAttribute="leading" id="mTe-H1-J6W"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="sHB-Bt-i1k" secondAttribute="bottom" id="I4W-aD-iD7"/>
+                            <constraint firstItem="sHB-Bt-i1k" firstAttribute="leading" secondItem="Pz5-VD-l9P" secondAttribute="leading" id="KmW-Ne-NtC"/>
+                            <constraint firstAttribute="trailing" secondItem="sHB-Bt-i1k" secondAttribute="trailing" id="Zfp-Af-EmA"/>
+                            <constraint firstItem="sHB-Bt-i1k" firstAttribute="top" secondItem="Pz5-VD-l9P" secondAttribute="top" id="fv8-tM-L9R"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="headerView" destination="WBG-zn-Bex" id="wKK-Dr-DHS"/>
+                    </connections>
+                </viewController>
+                <customObject id="zyQ-nT-SyA" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="395" y="1442"/>
+        </scene>
     </scenes>
     <resources>
         <image name="NSStopProgressFreestandingTemplate" width="20" height="20"/>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatMessageFieldView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatMessageFieldView.swift
@@ -33,6 +33,9 @@ class ChatMessageFieldView: NSView, LoadableNib {
     
     @IBOutlet weak var messageContainerHeightConstraint: NSLayoutConstraint!
     
+    @IBOutlet weak var addDocumentCustomView: NSView!
+    @IBOutlet weak var setPriceCustomView: NSBox!
+    
     let kTextViewVerticalMargins: CGFloat = 41
     let kCharacterLimit = 1000
     let kTextViewLineHeight: CGFloat = 19
@@ -61,6 +64,11 @@ class ChatMessageFieldView: NSView, LoadableNib {
         super.init(frame: frameRect)
         loadViewFromNib()
         setupView()
+    }
+    
+    func setupForThread() {
+        addDocumentCustomView.isHidden = true
+        setPriceCustomView.isHidden = true
     }
     
     func setupView() {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatMessageFieldView.xib
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatMessageFieldView.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ChatMessageFieldView" customModule="Sphinx" customModuleProvider="target">
             <connections>
+                <outlet property="addDocumentCustomView" destination="pT8-t2-gyi" id="LnR-2e-qa4"/>
                 <outlet property="attachmentsButton" destination="kzG-E7-i2c" id="6RS-ia-JlK"/>
                 <outlet property="contentView" destination="c22-O7-iKe" id="rs1-s4-020"/>
                 <outlet property="emojiButton" destination="tlx-Yr-Pwz" id="bwb-a9-y5o"/>
@@ -24,6 +25,7 @@
                 <outlet property="recordingContainer" destination="E5V-UG-0ys" id="zkC-F8-0q0"/>
                 <outlet property="recordingTimeLabel" destination="2LL-pO-iDQ" id="hMO-YB-rp4"/>
                 <outlet property="sendButton" destination="AH1-P5-0X5" id="3Ur-Ve-fEC"/>
+                <outlet property="setPriceCustomView" destination="QmM-Ic-bse" id="dSF-RQ-LzG"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
@@ -59,15 +61,15 @@
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kzG-E7-i2c" customClass="CustomButton" customModule="Sphinx" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="15" width="30" height="30"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="30" id="QSk-4U-g44"/>
-                                        <constraint firstAttribute="height" constant="30" id="e3r-Rb-c9x"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="bevel" title="" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="uYF-tD-t7M" customClass="VerticallyCenteredButtonCell" customModule="Sphinx" customModuleProvider="target">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" size="21" name="MaterialIcons-Regular"/>
                                     </buttonCell>
                                     <color key="contentTintColor" name="SphinxWhite"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="30" id="QSk-4U-g44"/>
+                                        <constraint firstAttribute="height" constant="30" id="e3r-Rb-c9x"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="attachmentsButtonClicked:" target="-2" id="JLo-QL-qHe"/>
                                     </connections>
@@ -84,15 +86,15 @@
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7ma-wQ-0Fe" customClass="CustomButton" customModule="Sphinx" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="19" width="23" height="23"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="23" id="37u-rk-MXo"/>
-                                        <constraint firstAttribute="width" constant="23" id="Lj1-My-kaG"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="giphyIcon" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Cg9-SO-lpL">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" size="25" name="MaterialIcons-Regular"/>
                                     </buttonCell>
                                     <color key="contentTintColor" name="MainBottomIcons"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="23" id="37u-rk-MXo"/>
+                                        <constraint firstAttribute="width" constant="23" id="Lj1-My-kaG"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="giphyButtonClicked:" target="-2" id="Ubh-C2-mYs"/>
                                     </connections>
@@ -109,15 +111,15 @@
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tlx-Yr-Pwz" customClass="CustomButton" customModule="Sphinx" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="18" width="25" height="25"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="25" id="XfY-aE-fbv"/>
-                                        <constraint firstAttribute="height" constant="25" id="dv5-B8-0kM"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="emojiIcon" imagePosition="only" alignment="center" imageScaling="axesIndependently" inset="2" id="Om5-9a-Kpk">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" size="25" name="MaterialIcons-Regular"/>
                                     </buttonCell>
                                     <color key="contentTintColor" name="MainBottomIcons"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="25" id="XfY-aE-fbv"/>
+                                        <constraint firstAttribute="height" constant="25" id="dv5-B8-0kM"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="emojiButtonClicked:" target="-2" id="MI6-sz-LqY"/>
                                     </connections>
@@ -192,7 +194,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="114" height="40"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h1e-oQ-Bka">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h1e-oQ-Bka">
                                         <rect key="frame" x="8" y="13" width="38" height="15"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Price:" id="Sbb-lb-Gbs">
                                             <font key="font" size="13" name="Roboto-Medium"/>
@@ -244,30 +246,30 @@
                         </box>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AH1-P5-0X5" customClass="CustomButton" customModule="Sphinx" customModuleProvider="target">
                             <rect key="frame" x="744" y="12" width="37" height="37"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="37" id="MRI-4t-8ES"/>
-                                <constraint firstAttribute="width" constant="37" id="hIE-HI-EgU"/>
-                            </constraints>
                             <buttonCell key="cell" type="bevel" title="" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="WCU-yd-wZa" customClass="VerticallyCenteredButtonCell" customModule="Sphinx" customModuleProvider="target">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" size="19" name="MaterialIcons-Regular"/>
                             </buttonCell>
                             <color key="contentTintColor" name="SphinxWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="37" id="MRI-4t-8ES"/>
+                                <constraint firstAttribute="width" constant="37" id="hIE-HI-EgU"/>
+                            </constraints>
                             <connections>
                                 <action selector="sendButtonClicked:" target="-2" id="qQX-cW-dtb"/>
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UcZ-ht-u51" customClass="CustomButton" customModule="Sphinx" customModuleProvider="target">
                             <rect key="frame" x="789" y="12" width="32" height="37"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="37" id="OOg-4O-kmn"/>
-                                <constraint firstAttribute="width" constant="32" id="OnS-2K-ubo"/>
-                            </constraints>
                             <buttonCell key="cell" type="bevel" title="mic" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="Dcl-Yq-lxq" customClass="VerticallyCenteredButtonCell" customModule="Sphinx" customModuleProvider="target">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" size="27" name="MaterialIcons-Regular"/>
                             </buttonCell>
                             <color key="contentTintColor" name="MainBottomIcons"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="37" id="OOg-4O-kmn"/>
+                                <constraint firstAttribute="width" constant="32" id="OnS-2K-ubo"/>
+                            </constraints>
                             <connections>
                                 <action selector="micButtonClicked:" target="-2" id="a3X-W6-jsZ"/>
                             </connections>
@@ -329,7 +331,7 @@
                                     <constraint firstAttribute="width" constant="59" id="h7J-Z4-vwD"/>
                                 </constraints>
                             </customView>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2LL-pO-iDQ">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2LL-pO-iDQ">
                                 <rect key="frame" x="652" y="18" width="43" height="24"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="0:00" id="7bN-oH-ieK">
                                     <font key="font" size="20" name="Roboto-Regular"/>
@@ -377,7 +379,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="XFh-GQ-R0E">
+                                                <button tag="1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XFh-GQ-R0E">
                                                     <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
                                                     <buttonCell key="cell" type="bevel" title="close" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="KFZ-da-7mf" customClass="VerticallyCenteredButtonCell" customModule="Sphinx" customModuleProvider="target">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
@@ -23,13 +23,11 @@ extension NewChatViewController : ChatHeaderViewDelegate {
                 windowSize: self.view.window?.frame.size
             )
           
-            WindowsManager.sharedInstance.showNewWindow(
-                with: "threads-list".localized,
-                size: CGSize(width: 450, height: 700),
-                centeredIn: self.view.window,
-                identifier: "threads-list",
-                contentVC: threadsListVC
-            )
+            WindowsManager.sharedInstance
+                .showVCOnRightmostPanelWindow(with: "threads-list".localized,
+                                              identifier: "threads-list",
+                                              contentVC: threadsListVC,
+                                              shouldReplace: false)
         }
     }
     

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
@@ -89,7 +89,7 @@ extension NewChatViewController : ChatHeaderViewDelegate {
             WindowsManager.sharedInstance.showChatDetailsWindow(
                 vc: contactVC,
                 window: view.window,
-                title: "contact".localized,
+                title: "contact.info".localized,
                 identifier: "contact-window",
                 size: CGSize(width: 414, height: 629)
 
@@ -105,7 +105,7 @@ extension NewChatViewController : ChatHeaderViewDelegate {
             WindowsManager.sharedInstance.showChatDetailsWindow(
                 vc: chatDetailsVC,
                 window: view.window,
-                title: "group.details".localized,
+                title: "tribe.info".localized,
                 identifier: "chat-window",
                 size: CGSize(width: 414, height: 629)
 

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
@@ -299,12 +299,14 @@ class NewChatViewController: DashboardSplittedViewController {
         guard let threadVC = threadVC else {
             return
         }
-
-        addChildVC(child: threadVC, container: threadVCContainer)
-
-        threadVC.setMessageFieldActive()
         
-        threadVCContainer.isHidden = false
+        WindowsManager.sharedInstance.showVCOnRightmostPanelWindow(with: "thread-chat".localized, identifier: "thread-chat-identifier", contentVC: threadVC, hideDivider: false, shouldReplace: true)
+//
+//        addChildVC(child: threadVC, container: threadVCContainer)
+//
+//        threadVC.setMessageFieldActive()
+//        
+//        threadVCContainer.isHidden = false
     }
     
     func resizeSubviews(frame: NSRect) {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
@@ -301,12 +301,6 @@ class NewChatViewController: DashboardSplittedViewController {
         }
         
         WindowsManager.sharedInstance.showVCOnRightmostPanelWindow(with: "thread-chat".localized, identifier: "thread-chat-identifier", contentVC: threadVC, hideDivider: false, shouldReplace: true)
-//
-//        addChildVC(child: threadVC, container: threadVCContainer)
-//
-//        threadVC.setMessageFieldActive()
-//        
-//        threadVCContainer.isHidden = false
     }
     
     func resizeSubviews(frame: NSRect) {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
@@ -300,7 +300,11 @@ class NewChatViewController: DashboardSplittedViewController {
             return
         }
         
-        WindowsManager.sharedInstance.showVCOnRightmostPanelWindow(with: "thread-chat".localized, identifier: "thread-chat-identifier", contentVC: threadVC, hideDivider: false, shouldReplace: true)
+        WindowsManager.sharedInstance
+            .showVCOnRightmostPanelWindow(with: "thread-chat".localized,
+                                          identifier: "thread-chat-identifier",
+                                          contentVC: threadVC,
+                                          shouldReplace: false)
     }
     
     func resizeSubviews(frame: NSRect) {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.swift
@@ -1,0 +1,46 @@
+//
+//  DashboardDetailHeaderView.swift
+//  Sphinx
+//
+//  Created by Oko-osi Korede on 18/04/2024.
+//  Copyright © 2024 Tomas Timinskas. All rights reserved.
+//
+
+import Cocoa
+
+protocol DetailHeaderViewDelegate: AnyObject {
+    func backButtonTapped()
+    func closeButtonTapped()
+}
+class DashboardDetailHeaderView: NSView, LoadableNib {
+    
+    weak var delegate: DetailHeaderViewDelegate?
+    
+    @IBOutlet var contentView: NSView!
+    @IBOutlet weak var closeButton: NSButton!
+    @IBOutlet weak var backButton: NSButton!
+    @IBOutlet weak var headerTitle: NSTextField!
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        loadViewFromNib()
+        setup()
+    }
+    
+    private func setup() {
+        hideBackButton(hide: true)
+    }
+    
+    @IBAction func backButtonTapped(_ sender: NSButton) {
+        delegate?.backButtonTapped()
+    }
+    
+    @IBAction func closeButtonTapped(_ sender: NSButton) {
+        delegate?.closeButtonTapped()
+    }
+    
+    func hideBackButton(hide: Bool) {
+        backButton.isHidden = hide
+    }
+    
+}

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.swift
@@ -31,6 +31,10 @@ class DashboardDetailHeaderView: NSView, LoadableNib {
         hideBackButton(hide: true)
     }
     
+    func setHeaderTitle(_ title: String) {
+        headerTitle.stringValue = title
+    }
+    
     @IBAction func backButtonTapped(_ sender: NSButton) {
         delegate?.backButtonTapped()
     }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
@@ -71,12 +71,15 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RQf-Sr-qKJ">
-                                            <rect key="frame" x="7" y="5.5" width="12.5" height="16"/>
+                                            <rect key="frame" x="7" y="5" width="12" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="12" id="HKB-9r-Rn5"/>
                                                 <constraint firstAttribute="width" constant="12" id="uUP-TU-khy"/>
                                             </constraints>
                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="xmark" catalog="system" id="Y0h-VW-4g6"/>
+                                            <symbolConfiguration key="symbolConfiguration" weight="heavy">
+                                                <nil key="locale"/>
+                                            </symbolConfiguration>
                                         </imageView>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="4M3-5v-ixa">
                                             <rect key="frame" x="0.0" y="0.0" width="26" height="26"/>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
@@ -31,11 +31,14 @@
                                 <rect key="frame" x="20" y="34" width="45" height="28"/>
                                 <subviews>
                                     <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="viw-Ea-oXk">
-                                        <rect key="frame" x="0.0" y="17.5" width="28" height="12"/>
+                                        <rect key="frame" x="0.0" y="17.5" width="28" height="13"/>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="arrow.left" catalog="system" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Frg-0M-gTq">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <symbolConfiguration key="symbolConfiguration" weight="heavy">
+                                            <nil key="locale"/>
+                                        </symbolConfiguration>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="28" id="Dk4-RT-h6M"/>
                                         </constraints>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="DashboardDetailHeaderView" customModule="Sphinx" customModuleProvider="target">
+            <connections>
+                <outlet property="backButton" destination="viw-Ea-oXk" id="FNz-JW-2v6"/>
+                <outlet property="closeButton" destination="4M3-5v-ixa" id="FRu-34-bKe"/>
+                <outlet property="contentView" destination="R65-74-UBK" id="WW5-OF-dbC"/>
+                <outlet property="headerTitle" destination="9oG-zA-O3y" id="8yz-Gb-JAW"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="R65-74-UBK">
+            <rect key="frame" x="0.0" y="0.0" width="490" height="96"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <box boxType="custom" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="wdV-xH-YDI">
+                    <rect key="frame" x="0.0" y="0.0" width="490" height="96"/>
+                    <view key="contentView" id="GGz-Dy-M3p">
+                        <rect key="frame" x="1" y="1" width="488" height="94"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="4M3-5v-ixa">
+                                <rect key="frame" x="442" y="31.5" width="28.5" height="32"/>
+                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="xmark" catalog="system" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="fOE-uK-5M9">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="28" id="WAg-s9-K8d"/>
+                                    <constraint firstAttribute="height" constant="28" id="evp-gy-4Bh"/>
+                                </constraints>
+                            </button>
+                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FhQ-xK-Ti1">
+                                <rect key="frame" x="20" y="33" width="402" height="28"/>
+                                <subviews>
+                                    <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="viw-Ea-oXk">
+                                        <rect key="frame" x="0.0" y="17.5" width="28" height="12"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="arrow.left" catalog="system" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Frg-0M-gTq">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="28" id="Dk4-RT-h6M"/>
+                                        </constraints>
+                                    </button>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9oG-zA-O3y">
+                                        <rect key="frame" x="-2" y="4" width="406" height="21"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Label" id="uDX-sy-Pfv">
+                                            <font key="font" size="18" name="Roboto-Bold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="pC5-9M-56p"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="4M3-5v-ixa" secondAttribute="trailing" constant="18" id="0Yw-Zk-gzy"/>
+                            <constraint firstItem="FhQ-xK-Ti1" firstAttribute="leading" secondItem="GGz-Dy-M3p" secondAttribute="leading" constant="20" id="Pe5-8R-Sev"/>
+                            <constraint firstItem="FhQ-xK-Ti1" firstAttribute="centerY" secondItem="GGz-Dy-M3p" secondAttribute="centerY" id="Tf3-0n-Xha"/>
+                            <constraint firstItem="4M3-5v-ixa" firstAttribute="leading" secondItem="FhQ-xK-Ti1" secondAttribute="trailing" constant="20" id="rxv-7f-Hgd"/>
+                            <constraint firstItem="4M3-5v-ixa" firstAttribute="centerY" secondItem="GGz-Dy-M3p" secondAttribute="centerY" id="tY1-rD-Aye"/>
+                        </constraints>
+                    </view>
+                    <color key="fillColor" name="HeaderBG"/>
+                </box>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="wdV-xH-YDI" secondAttribute="bottom" id="Qrt-rY-Wzi"/>
+                <constraint firstItem="wdV-xH-YDI" firstAttribute="leading" secondItem="R65-74-UBK" secondAttribute="leading" id="Xtx-Uv-67C"/>
+                <constraint firstAttribute="trailing" secondItem="wdV-xH-YDI" secondAttribute="trailing" id="jrm-dH-tN6"/>
+                <constraint firstItem="wdV-xH-YDI" firstAttribute="top" secondItem="R65-74-UBK" secondAttribute="top" id="lMz-8e-7qr"/>
+            </constraints>
+            <point key="canvasLocation" x="5.5" y="8"/>
+        </customView>
+    </objects>
+    <resources>
+        <image name="arrow.left" catalog="system" width="15" height="12"/>
+        <image name="xmark" catalog="system" width="14" height="13"/>
+        <namedColor name="HeaderBG">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DashboardDetailHeaderView.xib
@@ -21,25 +21,14 @@
             <rect key="frame" x="0.0" y="0.0" width="490" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box boxType="custom" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="wdV-xH-YDI">
-                    <rect key="frame" x="0.0" y="0.0" width="490" height="96"/>
+                <box boxType="custom" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="wdV-xH-YDI">
+                    <rect key="frame" x="0.0" y="1" width="490" height="95"/>
                     <view key="contentView" id="GGz-Dy-M3p">
-                        <rect key="frame" x="1" y="1" width="488" height="94"/>
+                        <rect key="frame" x="0.0" y="0.0" width="490" height="95"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="4M3-5v-ixa">
-                                <rect key="frame" x="442" y="31.5" width="28.5" height="32"/>
-                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="xmark" catalog="system" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="fOE-uK-5M9">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="28" id="WAg-s9-K8d"/>
-                                    <constraint firstAttribute="height" constant="28" id="evp-gy-4Bh"/>
-                                </constraints>
-                            </button>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FhQ-xK-Ti1">
-                                <rect key="frame" x="20" y="33" width="402" height="28"/>
+                                <rect key="frame" x="20" y="34" width="45" height="28"/>
                                 <subviews>
                                     <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="viw-Ea-oXk">
                                         <rect key="frame" x="0.0" y="17.5" width="28" height="12"/>
@@ -50,9 +39,12 @@
                                         <constraints>
                                             <constraint firstAttribute="width" constant="28" id="Dk4-RT-h6M"/>
                                         </constraints>
+                                        <connections>
+                                            <action selector="backButtonTapped:" target="-2" id="IZa-KF-loB"/>
+                                        </connections>
                                     </button>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9oG-zA-O3y">
-                                        <rect key="frame" x="-2" y="4" width="406" height="21"/>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9oG-zA-O3y">
+                                        <rect key="frame" x="-2" y="3" width="49" height="21"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Label" id="uDX-sy-Pfv">
                                             <font key="font" size="18" name="Roboto-Bold"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -72,20 +64,60 @@
                                     <real value="3.4028234663852886e+38"/>
                                 </customSpacing>
                             </stackView>
+                            <box borderType="line" title="Box" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JKs-qg-lLO">
+                                <rect key="frame" x="441" y="30" width="34" height="34"/>
+                                <view key="contentView" id="d92-eL-k8s">
+                                    <rect key="frame" x="4" y="5" width="26" height="26"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RQf-Sr-qKJ">
+                                            <rect key="frame" x="7" y="5.5" width="12.5" height="16"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="12" id="HKB-9r-Rn5"/>
+                                                <constraint firstAttribute="width" constant="12" id="uUP-TU-khy"/>
+                                            </constraints>
+                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="xmark" catalog="system" id="Y0h-VW-4g6"/>
+                                        </imageView>
+                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="4M3-5v-ixa">
+                                            <rect key="frame" x="0.0" y="0.0" width="26" height="26"/>
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="fOE-uK-5M9">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="26" id="Oor-ed-dTV"/>
+                                                <constraint firstAttribute="height" constant="26" id="kOZ-OU-V97"/>
+                                            </constraints>
+                                            <connections>
+                                                <action selector="closeButtonTapped:" target="-2" id="86z-om-BSN"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="4M3-5v-ixa" firstAttribute="centerY" secondItem="d92-eL-k8s" secondAttribute="centerY" id="bJV-Wt-XTc"/>
+                                        <constraint firstItem="RQf-Sr-qKJ" firstAttribute="centerY" secondItem="d92-eL-k8s" secondAttribute="centerY" id="dcJ-K5-QWr"/>
+                                        <constraint firstItem="4M3-5v-ixa" firstAttribute="centerX" secondItem="d92-eL-k8s" secondAttribute="centerX" id="pDf-L6-9xG"/>
+                                        <constraint firstItem="RQf-Sr-qKJ" firstAttribute="centerX" secondItem="d92-eL-k8s" secondAttribute="centerX" id="wMd-rJ-hUw"/>
+                                    </constraints>
+                                </view>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="28" id="ULo-jY-3ND"/>
+                                    <constraint firstAttribute="height" constant="28" id="vp7-yz-3LN"/>
+                                </constraints>
+                            </box>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="4M3-5v-ixa" secondAttribute="trailing" constant="18" id="0Yw-Zk-gzy"/>
                             <constraint firstItem="FhQ-xK-Ti1" firstAttribute="leading" secondItem="GGz-Dy-M3p" secondAttribute="leading" constant="20" id="Pe5-8R-Sev"/>
+                            <constraint firstItem="JKs-qg-lLO" firstAttribute="centerY" secondItem="GGz-Dy-M3p" secondAttribute="centerY" id="QY3-2B-Xgg"/>
                             <constraint firstItem="FhQ-xK-Ti1" firstAttribute="centerY" secondItem="GGz-Dy-M3p" secondAttribute="centerY" id="Tf3-0n-Xha"/>
-                            <constraint firstItem="4M3-5v-ixa" firstAttribute="leading" secondItem="FhQ-xK-Ti1" secondAttribute="trailing" constant="20" id="rxv-7f-Hgd"/>
-                            <constraint firstItem="4M3-5v-ixa" firstAttribute="centerY" secondItem="GGz-Dy-M3p" secondAttribute="centerY" id="tY1-rD-Aye"/>
+                            <constraint firstAttribute="trailing" secondItem="JKs-qg-lLO" secondAttribute="trailing" constant="18" id="Zbq-aP-dcx"/>
                         </constraints>
                     </view>
                     <color key="fillColor" name="HeaderBG"/>
                 </box>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="wdV-xH-YDI" secondAttribute="bottom" id="Qrt-rY-Wzi"/>
+                <constraint firstAttribute="bottom" secondItem="wdV-xH-YDI" secondAttribute="bottom" constant="1" id="Qrt-rY-Wzi"/>
                 <constraint firstItem="wdV-xH-YDI" firstAttribute="leading" secondItem="R65-74-UBK" secondAttribute="leading" id="Xtx-Uv-67C"/>
                 <constraint firstAttribute="trailing" secondItem="wdV-xH-YDI" secondAttribute="trailing" id="jrm-dH-tN6"/>
                 <constraint firstItem="wdV-xH-YDI" firstAttribute="top" secondItem="R65-74-UBK" secondAttribute="top" id="lMz-8e-7qr"/>

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/ThreadVCContainer.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/ThreadVCContainer.swift
@@ -12,4 +12,8 @@ class ThreadVCContainer: NSView {
     
     override func mouseDown(with event: NSEvent) {}
     
+    func resizeSubviews(frame: NSRect) {
+        self.frame = frame
+    }
+    
 }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/ThreadVCContainer.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/ThreadVCContainer.swift
@@ -12,8 +12,4 @@ class ThreadVCContainer: NSView {
     
     override func mouseDown(with event: NSEvent) {}
     
-    func resizeSubviews(frame: NSRect) {
-        self.frame = frame
-    }
-    
 }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
@@ -34,6 +34,10 @@ class DashboardDetailViewController: NSViewController {
     
     func resizeSubviews(frame: NSRect) {
         view.frame = frame
+        guard let currentVC = addedVC?.last else {
+            return
+        }
+        currentVC?.view.frame = containerView.bounds
     }
     
     func displayVC(_ vc: NSViewController, vcTitle: String, shouldReplace: Bool = true) {
@@ -46,6 +50,9 @@ class DashboardDetailViewController: NSViewController {
         updateVCTitle()
         ShowBackButton()
         self.addChildVC(child: vc, container: containerView)
+        guard let threadVC = vc as? NewChatViewController else { return }
+        threadVC.chatBottomView.messageFieldView.setupForThread()
+//        threadVC.resizeSubviews(frame: containerView.bounds)
     }
     
     func updateVCTitle() {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
@@ -7,14 +7,90 @@
 //
 
 import Cocoa
-
+protocol DashboardDetailDismissDelegate: AnyObject {
+    func closeButtonTapped()
+}
 class DashboardDetailViewController: NSViewController {
 
+    weak var dismissDelegate: DashboardDetailDismissDelegate?
+    
     @IBOutlet weak var headerView: DashboardDetailHeaderView!
+    @IBOutlet weak var containerView: ThreadVCContainer!
+    
+    var addedVC: [NSViewController?]? = []
+    var addedTitles: [String]? = []
+    
+    static func instantiate(delegate: DashboardDetailDismissDelegate? = nil) -> DashboardDetailViewController {
+        let viewController = StoryboardScene.Dashboard.dashboardDetailViewController.instantiate()
+        viewController.dismissDelegate = delegate
+        return viewController
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do view setup here.
+        headerView.delegate = self
+    }
+    
+    func resizeSubviews(frame: NSRect) {
+        view.frame = frame
+    }
+    
+    func displayVC(_ vc: NSViewController, vcTitle: String, shouldReplace: Bool = true) {
+        if shouldReplace {
+            backButtonTapped()
+        }
+        containerView.isHidden = false
+        addedVC?.append(vc)
+        addedTitles?.append(vcTitle)
+        updateVCTitle()
+        ShowBackButton()
+        self.addChildVC(child: vc, container: containerView)
+    }
+    
+    func updateVCTitle() {
+        let title = addedTitles?.last ?? ""
+        headerView.setHeaderTitle(title)
+    }
+    
+    func ShowBackButton() {
+        if addedVC?.count ?? 0 > 1 {
+            headerView.hideBackButton(hide: false)
+        } else {
+            headerView.hideBackButton(hide: true)
+        }
+    }
+}
+
+extension DashboardDetailViewController: DetailHeaderViewDelegate {
+    func backButtonTapped() {
+        print("Back button clicked")
+        if let last = addedVC?.last, let last {
+            self.removeChildVC(child: last)
+            self.addedTitles?.removeLast()
+            
+            if let addedVC, addedVC.count > 1,
+                let currentVC = addedVC[addedVC.count - 2] {
+                self.addChildVC(child: currentVC, container: containerView)
+                updateVCTitle()
+            }
+            
+            var lastVC = self.addedVC?.removeLast()
+            lastVC = nil
+            ShowBackButton()
+        }
+    }
+    
+    func closeButtonTapped() {
+        print("Close button clicked")
+        guard let addedVC else { return }
+        for vc in addedVC {
+            if let vc {
+                self.removeChildVC(child: vc)
+            }
+        }
+        self.addedVC?.removeAll()
+        dismissDelegate?.closeButtonTapped()
     }
     
 }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
@@ -52,7 +52,6 @@ class DashboardDetailViewController: NSViewController {
         self.addChildVC(child: vc, container: containerView)
         guard let threadVC = vc as? NewChatViewController else { return }
         threadVC.chatBottomView.messageFieldView.setupForThread()
-//        threadVC.resizeSubviews(frame: containerView.bounds)
     }
     
     func updateVCTitle() {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardDetailViewController.swift
@@ -1,0 +1,20 @@
+//
+//  DashboardDetailViewController.swift
+//  Sphinx
+//
+//  Created by Oko-osi Korede on 18/04/2024.
+//  Copyright © 2024 Tomas Timinskas. All rights reserved.
+//
+
+import Cocoa
+
+class DashboardDetailViewController: NSViewController {
+
+    @IBOutlet weak var headerView: DashboardDetailHeaderView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do view setup here.
+    }
+    
+}

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardViewController.swift
@@ -11,8 +11,10 @@ import Cocoa
 class DashboardViewController: NSViewController {
     
     @IBOutlet weak var dashboardSplitView: NSSplitView!
+    @IBOutlet weak var dashboardRightSplitView: NSSplitView!
     @IBOutlet weak var leftSplittedView: NSView!
     @IBOutlet weak var rightSplittedView: NSView!
+    @IBOutlet weak var rightDetailSplittedView: NSView!
     @IBOutlet weak var modalsContainerView: NSView!
     
     @IBOutlet weak var presenterBlurredBackground: NSVisualEffectView!
@@ -59,7 +61,7 @@ class DashboardViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        rightDetailSplittedView.isHidden = true
         AttachmentsManager.sharedInstance.runAuthentication(forceAuthenticate: true)
         
         listerForNotifications()
@@ -67,6 +69,8 @@ class DashboardViewController: NSViewController {
         chatListViewModel = ChatListViewModel()
         
         dashboardSplitView.delegate = self
+        dashboardRightSplitView.delegate = self
+        
         SphinxSocketManager.sharedInstance.setDelegate(delegate: self)
         
         let windowState = WindowsManager.sharedInstance.getWindowState()

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/DashboardViewController.swift
@@ -621,6 +621,7 @@ extension DashboardViewController : DashboardVCDelegate {
             child: newChatVCController,
             container: rightSplittedView
         )
+        dashboardDetailViewController?.closeButtonTapped()
         
         newDetailViewController = newChatVCController
         newDetailViewController?.setMessageFieldActive()

--- a/com.stakwork.sphinx.desktop/Scenes/Groups/View Controllers/GroupDetailsViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Groups/View Controllers/GroupDetailsViewController.swift
@@ -220,7 +220,11 @@ extension GroupDetailsViewController : MessageOptionsDelegate {
                 break
             case .Edit:
                 let createTribeVC = CreateTribeViewController.instantiate(chat: chat)
-                WindowsManager.sharedInstance.showCreateTribeWindow(title: "Create Tribe", vc: createTribeVC, window: NSApplication.shared.keyWindow)
+                WindowsManager.sharedInstance
+                    .showVCOnRightmostPanelWindow(with: "edit.tribe".localized,
+                                                  identifier: "edit-tribe-window",
+                                                  contentVC: createTribeVC,
+                                                  shouldReplace: false)
                 break
             }
         }

--- a/com.stakwork.sphinx.desktop/en.lproj/Localizable.strings
+++ b/com.stakwork.sphinx.desktop/en.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 "confirm.delete.keychain" = "Are you sure you want to permanently delete this node from keychain? Double check you are not connected to this node from other device, since this will remove the info from keychain causing that connection to be lost.";
 "error.restoring.keychain" = "There was an error restoring from Keychain.";
 "share.invite.code.upper" = "SHARE INVITATION CODE";
+"contact.info" = "Contact Info";
+"tribe.info" = "Tribe Info";
 "add.friend" = "Add Friend";
 "invalid.code.pubkey" = "This looks like a pubkey, to sign up you'll need an invite code from https://sphinx.chat";
 "invalid.code.invoice" = "This looks like an invoice, to sign up you'll need an invite code from https://sphinx.chat";

--- a/sphinx.xcodeproj/project.pbxproj
+++ b/sphinx.xcodeproj/project.pbxproj
@@ -590,6 +590,9 @@
 		934082792BC8827700FD7E34 /* DashboardPresenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934082782BC8827700FD7E34 /* DashboardPresenterViewController.swift */; };
 		93A83E6A2B7FC298005158FB /* SphinxProfileUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A83E692B7FC298005158FB /* SphinxProfileUITests.swift */; };
 		93A83E6C2B7FC298005158FB /* SphinxUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A83E6B2B7FC298005158FB /* SphinxUITestsLaunchTests.swift */; };
+		93E479242BD1C80800D0C9AB /* DashboardDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E479232BD1C80800D0C9AB /* DashboardDetailViewController.swift */; };
+		93E479262BD1CC1600D0C9AB /* DashboardDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E479252BD1CC1600D0C9AB /* DashboardDetailHeaderView.swift */; };
+		93E479282BD1CCFE00D0C9AB /* DashboardDetailHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 93E479272BD1CCFE00D0C9AB /* DashboardDetailHeaderView.xib */; };
 		AA1C7BC427657C4800A5B959 /* SignupCommonSecureFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1C7BC327657C4800A5B959 /* SignupCommonSecureFieldView.swift */; };
 		CE07F40529D72B7700EB0EC1 /* PodcastDetailSelectionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE07F40429D72B7700EB0EC1 /* PodcastDetailSelectionVC.swift */; };
 		CE1FA8F82A0199C20014360C /* LSATObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FA8F72A0199C20014360C /* LSATObject.swift */; };
@@ -1521,6 +1524,9 @@
 		93A83E672B7FC297005158FB /* SphinxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SphinxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		93A83E692B7FC298005158FB /* SphinxProfileUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphinxProfileUITests.swift; sourceTree = "<group>"; };
 		93A83E6B2B7FC298005158FB /* SphinxUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphinxUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		93E479232BD1C80800D0C9AB /* DashboardDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDetailViewController.swift; sourceTree = "<group>"; };
+		93E479252BD1CC1600D0C9AB /* DashboardDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDetailHeaderView.swift; sourceTree = "<group>"; };
+		93E479272BD1CCFE00D0C9AB /* DashboardDetailHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DashboardDetailHeaderView.xib; sourceTree = "<group>"; };
 		97A6F8CB5E1D14A28D7C7A67 /* Pods-com.stakwork.sphinx.desktop.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-com.stakwork.sphinx.desktop.release.xcconfig"; path = "Target Support Files/Pods-com.stakwork.sphinx.desktop/Pods-com.stakwork.sphinx.desktop.release.xcconfig"; sourceTree = "<group>"; };
 		AA1C7BC327657C4800A5B959 /* SignupCommonSecureFieldView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupCommonSecureFieldView.swift; sourceTree = "<group>"; };
 		CE07F40429D72B7700EB0EC1 /* PodcastDetailSelectionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastDetailSelectionVC.swift; sourceTree = "<group>"; };
@@ -2687,6 +2693,7 @@
 				479751C9246C732C00D2106B /* DashboardViewController.swift */,
 				479751FD246EE0AE00D2106B /* DashboardSplittedViewController.swift */,
 				934082782BC8827700FD7E34 /* DashboardPresenterViewController.swift */,
+				93E479232BD1C80800D0C9AB /* DashboardDetailViewController.swift */,
 				473437AD24DB12B300950F25 /* Profile */,
 				479751FF246F014700D2106B /* Custom Views */,
 				479751E6246D919A00D2106B /* Chat List */,
@@ -2771,6 +2778,7 @@
 		479751FF246F014700D2106B /* Custom Views */ = {
 			isa = PBXGroup;
 			children = (
+				93E479252BD1CC1600D0C9AB /* DashboardDetailHeaderView.swift */,
 				47975200246F017800D2106B /* ChatAvatarView.swift */,
 				47975202246F018300D2106B /* ChatAvatarView.xib */,
 				4787F89F247C16B200CCE8B9 /* ChatSmallAvatarView.swift */,
@@ -2794,6 +2802,7 @@
 				47469D5A2ACB6012004F0490 /* NewMessagesIndicatorView.swift */,
 				47469D5C2ACB6019004F0490 /* NewMessagesIndicatorView.xib */,
 				47469D6E2AD7101C004F0490 /* ThreadVCContainer.swift */,
+				93E479272BD1CCFE00D0C9AB /* DashboardDetailHeaderView.xib */,
 			);
 			path = "Custom Views";
 			sourceTree = "<group>";
@@ -3693,6 +3702,7 @@
 				4724BC1A25474BE70012BD76 /* Podcast.storyboard in Resources */,
 				479E7D8925ADD6DD0092595B /* PinTimeoutView.xib in Resources */,
 				4797E87E24BCD69F00D13270 /* CommonPaymentView.xib in Resources */,
+				93E479282BD1CCFE00D0C9AB /* DashboardDetailHeaderView.xib in Resources */,
 				474C7A3E28D213E1007A3E17 /* NotificationLevelView.xib in Resources */,
 				4744FAAB2469D1BC00C5FD94 /* Colors.xcassets in Resources */,
 				478ED5DA25D6FD6B00940132 /* ProfileImageView.xib in Resources */,
@@ -4095,6 +4105,7 @@
 				CE326B51294A179200821A53 /* ChatMentionAutocompleteCell.swift in Sources */,
 				47C6236125091C02005D265C /* GiphySearchCollectionViewItem.swift in Sources */,
 				475B682E29915D8A000EF29C /* ContentFeedPaymentModel+Computeds.swift in Sources */,
+				93E479262BD1CC1600D0C9AB /* DashboardDetailHeaderView.swift in Sources */,
 				4797E7552785E1240080B966 /* API+PeopleExtension.swift in Sources */,
 				4734D3C52417E48600D6957E /* EncryptionManager.swift in Sources */,
 				47F8825A25656CB0002A7E71 /* SocketEventHandler.swift in Sources */,
@@ -4196,6 +4207,7 @@
 				4744FA9B2469CB2400C5FD94 /* ChatListCommonObject.swift in Sources */,
 				479751E5246D909F00D2106B /* WalletBalanceService.swift in Sources */,
 				470708A624B36C8A00A98DCA /* MetaDataCache.swift in Sources */,
+				93E479242BD1C80800D0C9AB /* DashboardDetailViewController.swift in Sources */,
 				4744FA9D2469CD0B00C5FD94 /* AttachmentsManager.swift in Sources */,
 				473E1F2C2AC45BB500DC1CDC /* ThreadRepliesView.swift in Sources */,
 				473BC88F2600EEFF0070E519 /* NewEpisodeAlertView.swift in Sources */,


### PR DESCRIPTION
# Pull Request Title
## Implementation of Right panel navigation changes https://github.com/stakwork/sphinx-mac/issues/342

### Description
This pull request addresses the  Implementation of Right panel navigation changes in Issue  https://github.com/stakwork/sphinx-mac/issues/342.

### The following are the addressed issues:
- All the chat secondary views will now show in a right panel instead of showing as new windows. Similar to how we show the podcast player on tribes with a podcast. This will apply to the following views:
    - Tribe details / Share Tribe QR code / Edit Tribe
    - Contact Details / Contact Public key QR code
    - Threads list
    - Thread view
 
## Changes Made
- StoryboardScenes.swift:
    - updated this file to have the instance of DashboardDetailViewController as dashboardDetailViewController
- WindowsManager.swift:
    - Added a method called showVCOnRightmostPanelWindow with the implementation to present any viewcontroller passed to need
    - Updated the showPubKeyWindow method to use the showVCOnRightmostPanelWindow
    - Updated the showTribeQRWindow method to use the showVCOnRightmostPanelWindow
    - Updated the showChatDetailsWindow method to use the showVCOnRightmostPanelWindow
- Dashboard.storyboard:
    - Updated the dashboard interface builder to include the split view
    - Added a new interface builder for 
- ChatMessageFieldView.xib:
    - Linked the custom view to be customised (hidden) with the swift file 
- ChatMessageFieldView.swift:
    - Update ChatMessageFieldView so as to customised the bottom view of the ThreadView for adding  newThreads
- NewChatViewController+BottomTopBarsExtension.swift:
    - Updated the title for the Tribe and Contact Views
- NewChatViewController.swift:
    - Updated the method showThread to implement the new navigation change
- DashboardDetailHeaderView: 
    - Create protocol DetailHeaderViewDelegate for handling back and close actions from button clicked
    - Created DashboardDetailHeaderView for the header view of the new navigation view
- DashboardDetailHeaderView.xib:  
    - Create the custom header view using interface builder
- DashboardDetailViewController.swift:
    - Created this file to be the base controller for the rightmost panel 
    - Created the DashboardDetailDismissDelegate to handle the dismissal of the RightPanel View- DashboardViewController.swift:
    - Updated this to cater for the changes made on the interface builder for smooth navigation changes implementation