### PR TITLE
Test flight new designs for attachments preview on chat

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/NewChatMessageFieldView/NewChatMessageFieldView+MentionsMacrosExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/NewChatMessageFieldView/NewChatMessageFieldView+MentionsMacrosExtension.swift
@@ -278,6 +278,7 @@ extension NewChatMessageFieldView {
 
 extension NewChatMessageFieldView: NewChatAttachmentDelegate {
     func closePreview(at index: Int?) {
+        fileDroppedCounter -= 1
         var menuItems = newChatAttachmentView.menuItems
         if let index, menuItems.count > index {
             menuItems.remove(at: index)

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/NewChatMessageFieldView/NewChatMessageFieldView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/NewChatMessageFieldView/NewChatMessageFieldView.swift
@@ -67,6 +67,8 @@ class NewChatMessageFieldView: NSView, LoadableNib {
         }
     }
     
+    var fileDroppedCounter: Int = 0 // Count the number of files dropped
+    
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
     }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+CollectionViewExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+CollectionViewExtension.swift
@@ -314,23 +314,38 @@ extension NewChatViewController: ShowPreviewDelegate {
     }
     
     func showPreview(data: Data, image: NSImage, type: AttachmentItemType) {
-        let newItem = NewAttachmentItem(previewImage: image, previewType: type, previewData: data)
-        let currentItems = chatBottomView.messageFieldView.newChatAttachmentView.menuItems + [newItem]
-        updateAddButton(currentItems: currentItems, hasText: !chatBottomView.messageFieldView.messageTextView.string.isEmpty)
-        chatBottomView.messageFieldView.newChatAttachmentView.updateCollectionView(menuItems: currentItems)
-        draggingView.resetView()
-        chatBottomView.messageFieldView.newChatAttachmentView.isHidden = false
-        _ = chatBottomView.messageFieldView.updateBottomBarHeight()
+        if chatBottomView.messageFieldView.fileDroppedCounter <= totalFileDroppable {
+            chatBottomView.messageFieldView.fileDroppedCounter += 1
+            let newItem = NewAttachmentItem(previewImage: image, previewType: type, previewData: data)
+            let currentItems = chatBottomView.messageFieldView.newChatAttachmentView.menuItems + [newItem]
+            updateAddButton(currentItems: currentItems, hasText: !chatBottomView.messageFieldView.messageTextView.string.isEmpty)
+            chatBottomView.messageFieldView.newChatAttachmentView.updateCollectionView(menuItems: currentItems)
+            draggingView.resetView()
+            chatBottomView.messageFieldView.newChatAttachmentView.isHidden = false
+            _ = chatBottomView.messageFieldView.updateBottomBarHeight()
+        } else {
+            AlertHelper.showAlert(title: "Failed To Upload", message: "Unable to attach the file")
+            draggingView.resetView()
+        }
+        
     }
     
     func showVideoFilePreview(data: Data, image: NSImage? = nil, type: AttachmentItemType, url: URL) {
-        let newItem = NewAttachmentItem(previewImage: NSImage(data: data) ?? NSImage(), previewType: type, previewData: data, previewURL: url)
-        let currentItems = chatBottomView.messageFieldView.newChatAttachmentView.menuItems + [newItem]
-        updateAddButton(currentItems: currentItems, hasText: !chatBottomView.messageFieldView.messageTextView.string.isEmpty)
-        chatBottomView.messageFieldView.newChatAttachmentView.updateCollectionView(menuItems: currentItems)
-        draggingView.resetView()
-        chatBottomView.messageFieldView.newChatAttachmentView.isHidden = false
-        _ = chatBottomView.messageFieldView.updateBottomBarHeight()
+        
+        if chatBottomView.messageFieldView.fileDroppedCounter <= totalFileDroppable {
+            chatBottomView.messageFieldView.fileDroppedCounter += 1
+            let newItem = NewAttachmentItem(previewImage: NSImage(data: data) ?? NSImage(), previewType: type, previewData: data, previewURL: url)
+            let currentItems = chatBottomView.messageFieldView.newChatAttachmentView.menuItems + [newItem]
+            updateAddButton(currentItems: currentItems, hasText: !chatBottomView.messageFieldView.messageTextView.string.isEmpty)
+            chatBottomView.messageFieldView.newChatAttachmentView.updateCollectionView(menuItems: currentItems)
+            draggingView.resetView()
+            chatBottomView.messageFieldView.newChatAttachmentView.isHidden = false
+            _ = chatBottomView.messageFieldView.updateBottomBarHeight()
+        } else {
+            AlertHelper.showAlert(title: "Failed To Upload", message: "Unable to attach the file")
+            draggingView.resetView()
+        }
+        
     }
     
     func updateAddButton(currentItems: [NewAttachmentItem], hasText: Bool = false) {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
@@ -81,6 +81,8 @@ class NewChatViewController: DashboardSplittedViewController {
     var podcastPlayerVC: NewPodcastPlayerViewController? = nil
     var threadVC: NewChatViewController? = nil
     
+    let totalFileDroppable = 9 // Set the maximum number of files that can be dropped
+    
     static func instantiate(
         contactId: Int? = nil,
         chatId: Int? = nil,

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DraggingDestinationView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/DraggingDestinationView.swift
@@ -320,48 +320,65 @@ class DraggingDestinationView: NSView, LoadableNib {
         let filteringOptionsCount = filteringOptions[NSPasteboard.ReadingOptionKey.urlReadingContentsConformToTypes]?.count ?? 0
         let options = filteringOptionsCount > 0 ? filteringOptions : nil
 
-        if let urls = pasteBoard.readObjects(forClasses: [NSURL.self], options: options) as? [URL], urls.count == 1 {
-            let url = urls[0]
-            
-            if !url.absoluteString.starts(with: "file://") {
-                return false
-            }
-            
-            if let data = getDataFrom(url: url) {
-                fileName = (url.absoluteString as NSString).lastPathComponent.percentNotEscaped
+        if let urls = pasteBoard.readObjects(forClasses: [NSURL.self], options: options) as? [URL], urls.count <= 10 {
+            for url in urls {
+//                let url = urls[0]
                 
-                if let image = NSImage(contentsOf: url) {
-                    if url.isPDF {
-                        previewDelegate?.showPDFPreview(data: data, image: image, url: url)
-//                        showPDFPreview(data: data, image: image, url: url)
-                    } else if data.isAnimatedImage() {
-//                        showGIFPreview(data: data, image: image)
-                        previewDelegate?.showGIFPreview(data: data, image: image)
-                    } else {
-                        previewDelegate?.showImagePreview(data: data, image: image)
-//                        showImagePreview(data: data, image: image)
-                    }
-                } else if url.isVideo {
-                    previewDelegate?.showVideoPreview(data: data, url: url)
-//                    showVideoPreview(data: data, url: url)
-                } else {
-                    previewDelegate?.showFilePreview(data: data, url: url)
-//                    showFilePreview(data: data, url: url)
+                if !url.absoluteString.starts(with: "file://") {
+                    return false
                 }
-                return true
+                
+                if let data = getDataFrom(url: url) {
+                    fileName = (url.absoluteString as NSString).lastPathComponent.percentNotEscaped
+                    
+                    if let image = NSImage(contentsOf: url) {
+                        if url.isPDF {
+                            previewDelegate?.showPDFPreview(data: data, image: image, url: url)
+    //                        showPDFPreview(data: data, image: image, url: url)
+                        } else if data.isAnimatedImage() {
+    //                        showGIFPreview(data: data, image: image)
+                            previewDelegate?.showGIFPreview(data: data, image: image)
+                        } else {
+                            previewDelegate?.showImagePreview(data: data, image: image)
+    //                        showImagePreview(data: data, image: image)
+                        }
+                    } else if url.isVideo {
+                        previewDelegate?.showVideoPreview(data: data, url: url)
+    //                    showVideoPreview(data: data, url: url)
+                    } else {
+                        previewDelegate?.showFilePreview(data: data, url: url)
+    //                    showFilePreview(data: data, url: url)
+                    }
+                    
+                }
             }
+            return true
         }
         if let images = pasteBoard.readObjects(forClasses: [NSImage.self]),
-            images.count > 0,
-            let image = images[0] as? NSImage,
-            let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
-            
-            let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
-            if let jpegData = bitmapRep.representation(using: NSBitmapImageRep.FileType.jpeg, properties: [:]) {
-                showImagePreview(data: jpegData, image: image)
-                return true
+           images.count > 0 {
+            for pos in 0 ..< images.count {
+                if let image = images[pos] as? NSImage,
+                   let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+                    
+                    let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
+                    if let jpegData = bitmapRep.representation(using: NSBitmapImageRep.FileType.jpeg, properties: [:]) {
+                        showImagePreview(data: jpegData, image: image)
+                        return true
+                    }
+                }
             }
         }
+//        if let images = pasteBoard.readObjects(forClasses: [NSImage.self]),
+//            images.count > 0,
+//            let image = images[0] as? NSImage,
+//            let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+//            
+//            let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
+//            if let jpegData = bitmapRep.representation(using: NSBitmapImageRep.FileType.jpeg, properties: [:]) {
+//                showImagePreview(data: jpegData, image: image)
+//                return true
+//            }
+//        }
         return false
     }
     


### PR DESCRIPTION
# Pull Request Title
## Allow drag and drop of multiple files https://github.com/stakwork/sphinx-mac/issues/413

### Description
This pull request addresses the Allow drag and drop of multiple files in Issue https://github.com/stakwork/sphinx-mac/issues/413.

### The following are the addressed issues:
- Allow dragging and dropping multiple files at a time
- The new attachments preview view should support up to 10 files

## Changes Made
- NewChatMessageFieldView.swift:
    - Added property for keeping track of number of files attached
- NewChatMessageFieldView.swift:
    - Reduces the file counter property value by 1 for each close button tapped
- NewChatViewController+CollectionViewExtension.swift:
    - Updated the showPreview method to handle multiple file attachment
    - Updated the showVideoFilePreview method to handle multiple file attachment
- NewChatViewController.swift:
    - Added the totalFileDroppable property for limiting the number of file attachable
- DraggingDestinationView.swift:
    - Updated the processURLs method to handle multiple files upload at a time 
 
## Link to Recording
- https://www.loom.com/share/ae930f9ebe1c47b0a65ebd32c78643b1?sid=bbfe9c94-cb61-46f5-8371-2167e852ba50